### PR TITLE
feat: append support to using `pathPrefix`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ module.exports = (
     // Calculate the paddingBottom %
 
     const sourceTags = transcodeResult.videos.map(video => {
-      return `<source src="${video.src}" type="video/${video.fileExtension}">`
+      return `<source src="${pathPrefix || ''}${video.src}" type="video/${video.fileExtension}">`
     })
     /*
     console.log(


### PR DESCRIPTION

In the situation, which you would like to deploy with `pathPrefix` (for example, GitLab pages) ,
video source tags generated by `gatsby-remark-videos` does not show paths correctly.

Could you merge this pull request and support using `pathPrefix` ?